### PR TITLE
Revert "chore(deps): update dependency ansible to v11 (#506)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ HiYaPyCo==0.7.0
 Jinja2==3.1.4
 Mako==1.3.6
 PyYAML==6.0.2
-ansible==11.0.0
+ansible==10.6.0
 docker==7.1.0
 loguru==0.7.2
 requests==2.32.3


### PR DESCRIPTION
This reverts commit 207d8f4dfafc3c173fe33af7b83ba3212e721fb3.

ERROR: No matching distribution found for ansible==11.0.0