### PR TITLE
2024.2: use magnumclient 4.8.1

### DIFF
--- a/patches/2024.2/openstack_requirements/magnumclient.patch
+++ b/patches/2024.2/openstack_requirements/magnumclient.patch
@@ -1,0 +1,11 @@
+--- a/upper-constraints.txt
++++ b/upper-constraints.txt
+@@ -546,7 +546,7 @@ python-keystoneclient===5.5.0
+ ceilometer===23.0.0.0rc1
+ diskimage-builder===3.33.0
+ heat-translator===3.1.0
+-python-magnumclient===4.7.0
++python-magnumclient===4.8.1
+ docker===7.1.0
+ storops===1.2.11
+ anyio===4.4.0

--- a/scripts/002-generate.sh
+++ b/scripts/002-generate.sh
@@ -53,7 +53,10 @@ setini DEFAULT tag $DOCKER_TAG
 setini DEFAULT base $KOLLA_BASE
 setini DEFAULT base_tag $KOLLA_BASE_TAG
 setini DEFAULT install_type $KOLLA_INSTALL_TYPE
-setini openstack-base location https://tarballs.opendev.org/openstack/requirements/requirements-stable-$OPENSTACK_VERSION.tar.gz
+setini openstack-base location tarballs/requirements-stable-$OPENSTACK_VERSION.tar.gz
+sed -i "/\[openstack-base\]/a # tarball = https://tarballs.opendev.org/openstack/requirements/requirements-stable-$OPENSTACK_VERSION.tar.gz" $KOLLA_CONF_FILE
+setini openstack-base type local
+
 
 if [[ -n $DOCKER_REGISTRY ]]; then
     setini DEFAULT registry $DOCKER_REGISTRY


### PR DESCRIPTION
Required because of:

https://review.opendev.org/c/openstack/python-magnumclient/+/937537