### PR TITLE
Do not sign base images with cosign

### DIFF
--- a/scripts/100-push.sh
+++ b/scripts/100-push.sh
@@ -46,6 +46,6 @@ cat other.log
 curl -O -L "https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64"
 chmod +x cosign-linux-amd64
 
-for image in $(cat $LSTFILE); do
+for image in $(cat $LSTFILE | grep -v base); do
     ./cosign-linux-amd64 sign --yes --key env://COSIGN_PRIVATE_KEY "$image"
 done


### PR DESCRIPTION
We do not push them. It's not necessary to sign them.