### PR TITLE
Revert "zuul: allow up to three push jobs (#627)"

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -59,19 +59,19 @@
 
 - semaphore:
     name: semaphore-container-images-kolla-push-2024.1
-    max: 3
+    max: 1
 
 - semaphore:
     name: semaphore-container-images-kolla-push-2024.2
-    max: 3
+    max: 1
 
 - semaphore:
     name: semaphore-container-images-kolla-push-2025.1
-    max: 3
+    max: 1
 
 - semaphore:
     name: semaphore-container-images-kolla-push-2024.2-aarch64
-    max: 3
+    max: 1
 
 - job:
     name: container-images-kolla-patch


### PR DESCRIPTION
This reverts commit 92b4963c892713c1858afcad05fbc7041b3ef53a.

This does not work well and causes serious problems for the harbor service.