### PR TITLE
Fix black 26.3.1 formatting

### DIFF
--- a/overlays/2024.1/cinder/source/cinder/volume/drivers/linstordrv.py
+++ b/overlays/2024.1/cinder/source/cinder/volume/drivers/linstordrv.py
@@ -18,6 +18,7 @@
 See https://docs.linbit.com/docs/users-guide-9.0/#ch-openstack-linstor
 for more details.
 """
+
 import contextlib
 import functools
 import socket

--- a/overlays/2024.2/cinder/source/cinder/volume/drivers/linstordrv.py
+++ b/overlays/2024.2/cinder/source/cinder/volume/drivers/linstordrv.py
@@ -18,6 +18,7 @@
 See https://docs.linbit.com/docs/users-guide-9.0/#ch-openstack-linstor
 for more details.
 """
+
 import contextlib
 import functools
 import socket

--- a/src/compare-sbom.py
+++ b/src/compare-sbom.py
@@ -36,7 +36,6 @@ from loguru import logger
 from packaging.version import Version, InvalidVersion
 from yaml import safe_load, YAMLError
 
-
 # Configure logger
 logger.remove()
 log_fmt = (


### PR DESCRIPTION
## Summary
- Reformat code to comply with black 26.3.1 stable style (updated in osism/zuul-jobs#180)

## Test plan
- [ ] python-black Zuul job passes