### PR TITLE
2025.1: refresh keystonemiddleware.patch context

### DIFF
--- a/patches/2025.1/openstack_requirements/keystonemiddleware.patch
+++ b/patches/2025.1/openstack_requirements/keystonemiddleware.patch
@@ -4,7 +4,7 @@
  XStatic-tv4===1.2.7.0
  XStatic-JSEncrypt===2.3.1.1
  python-cinderclient===9.7.0
--keystonemiddleware===10.9.0
+-keystonemiddleware===10.9.1
 +keystonemiddleware===10.12.1
  django-formtools===2.5.1
  XStatic-Spin===1.2.5.3


### PR DESCRIPTION
## Summary

- Upstream `requirements-stable-2025.1` was republished with `keystonemiddleware` bumped from `10.9.0` → `10.9.1`, shifting the line and breaking hunk #1 of `patches/2025.1/openstack_requirements/keystonemiddleware.patch`.
- As a result, the `container-images-kolla-patch-2025.1` Zuul job has been failing on every PR since #714 was merged (e.g. #716, #717, #718).
- Refresh the pre-image to `10.9.1` so the patch applies cleanly again. The post-image (`10.12.1`, originally from the CVE-2026-22797 fix in #677) is unchanged, and hunk #2 (`oslo.cache`) was already clean.

## Test plan

- [ ] `container-images-kolla-patch-2025.1` Zuul job passes