### PR TITLE
Add missing semaphore for 2025.2 push job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -69,6 +69,10 @@
     name: semaphore-container-images-kolla-push-2025.1
     max: 1
 
+- semaphore:
+    name: semaphore-container-images-kolla-push-2025.2
+    max: 1
+
 - job:
     name: container-images-kolla-patch
     nodeset: ubuntu-noble


### PR DESCRIPTION
The container-images-kolla-push-2025.2 job references the semaphore-container-images-kolla-push-2025.2 semaphore, but it was never defined. Add the definition to match the other release versions.