### PR TITLE
Revert MariaDB pin: MDEV-39685 fix shipped

### DIFF
--- a/templates/2024.2/apt_preferences.ubuntu.j2
+++ b/templates/2024.2/apt_preferences.ubuntu.j2
@@ -5,7 +5,3 @@ Pin-Priority: 1000
 Package: openvswitch*
 Pin: version 3.4.*
 Pin-Priority: 1000
-
-Package: mariadb-* libmariadb* mysql-common
-Pin: version 1:10.11.16*
-Pin-Priority: 1001

--- a/templates/2025.1/apt_preferences.ubuntu.j2
+++ b/templates/2025.1/apt_preferences.ubuntu.j2
@@ -9,7 +9,3 @@ Pin-Priority: 1000
 Package: erlang*
 Pin: version 1:27.*
 Pin-Priority: 1000
-
-Package: mariadb-* libmariadb* mysql-common
-Pin: version 1:10.11.16*
-Pin-Priority: 1001

--- a/templates/2025.2/apt_preferences.ubuntu.j2
+++ b/templates/2025.2/apt_preferences.ubuntu.j2
@@ -9,7 +9,3 @@ Pin-Priority: 1000
 Package: erlang*
 Pin: version 1:27.*
 Pin-Priority: 1000
-
-Package: mariadb-* libmariadb* mysql-common
-Pin: version 1:11.4.10*
-Pin-Priority: 1001


### PR DESCRIPTION
Reverts the MariaDB pre-MDEV-39685 pin added in #725 (commit `cb7e25e`).

## Why

#725 pinned the MariaDB binary family to the last pre-MDEV-39685
versions (`1:10.11.16*` for 2024.2/2025.1, `1:11.4.10*` for 2025.2) to
keep MDEV-39685 — the Galera multi-table UPDATE SIGSEGV regression in
10.11.17 / 11.4.11 — out of the nightly kolla images. See the
investigation in `~/issues/ci/attic/tempest-keystone-token-500-cascade.md`.

The fix releases are now published in the dlm.mariadb.com apt repo and
confirmed served from the `noble` component:

| Series | Fixed version served       | Used by         |
|--------|----------------------------|-----------------|
| 10.11  | `1:10.11.18+maria~ubu2404` | 2024.2 / 2025.1 |
| 11.4   | `1:11.4.12+maria~ubu2404`  | 2025.2          |

The morning `mariadb-10.11-watch` check has flipped to
`*** FIX AVAILABLE *** latest=10.11.18`.

## What

Removes the `mariadb-* libmariadb* mysql-common` Pin blocks from all
three `apt_preferences.ubuntu.j2` templates (2024.2, 2025.1, 2025.2).
The next nightly kolla build then picks up the fixed MariaDB versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)