### PR TITLE
Pin proxysql to 3.0.8 to keep api-int VIP up

### DIFF
--- a/templates/2024.1/apt_preferences.ubuntu.j2
+++ b/templates/2024.1/apt_preferences.ubuntu.j2
@@ -5,3 +5,12 @@ Pin-Priority: 1000
 Package: openvswitch*
 Pin: version 3.3.*
 Pin-Priority: 1000
+
+# Stopgap: proxysql 3.0.9 (GHSA-58ww-865x-grpr bounds the first-packet
+# recv()) rejects the kolla-ansible keepalived proxysql health check (the
+# "show info" probe) -> keepalived FAULT -> api-int VIP dropped. Pin to
+# 3.0.8 until the upstream fix (kolla-ansible change 992020, depends on
+# kolla 992239, master-only) is backported to this release.
+Package: proxysql
+Pin: version 3.0.8*
+Pin-Priority: 1001

--- a/templates/2024.2/apt_preferences.ubuntu.j2
+++ b/templates/2024.2/apt_preferences.ubuntu.j2
@@ -5,3 +5,12 @@ Pin-Priority: 1000
 Package: openvswitch*
 Pin: version 3.4.*
 Pin-Priority: 1000
+
+# Stopgap: proxysql 3.0.9 (GHSA-58ww-865x-grpr bounds the first-packet
+# recv()) rejects the kolla-ansible keepalived proxysql health check (the
+# "show info" probe) -> keepalived FAULT -> api-int VIP dropped. Pin to
+# 3.0.8 until the upstream fix (kolla-ansible change 992020, depends on
+# kolla 992239, master-only) is backported to this release.
+Package: proxysql
+Pin: version 3.0.8*
+Pin-Priority: 1001

--- a/templates/2025.1/apt_preferences.ubuntu.j2
+++ b/templates/2025.1/apt_preferences.ubuntu.j2
@@ -9,3 +9,12 @@ Pin-Priority: 1000
 Package: erlang*
 Pin: version 1:27.*
 Pin-Priority: 1000
+
+# Stopgap: proxysql 3.0.9 (GHSA-58ww-865x-grpr bounds the first-packet
+# recv()) rejects the kolla-ansible keepalived proxysql health check (the
+# "show info" probe) -> keepalived FAULT -> api-int VIP dropped. Pin to
+# 3.0.8 until the upstream fix (kolla-ansible change 992020, depends on
+# kolla 992239, master-only) is backported to this release.
+Package: proxysql
+Pin: version 3.0.8*
+Pin-Priority: 1001

--- a/templates/2025.2/apt_preferences.ubuntu.j2
+++ b/templates/2025.2/apt_preferences.ubuntu.j2
@@ -9,3 +9,12 @@ Pin-Priority: 1000
 Package: erlang*
 Pin: version 1:27.*
 Pin-Priority: 1000
+
+# Stopgap: proxysql 3.0.9 (GHSA-58ww-865x-grpr bounds the first-packet
+# recv()) rejects the kolla-ansible keepalived proxysql health check (the
+# "show info" probe) -> keepalived FAULT -> api-int VIP dropped. Pin to
+# 3.0.8 until the upstream fix (kolla-ansible change 992020, depends on
+# kolla 992239, master-only) is backported to this release.
+Package: proxysql
+Pin: version 3.0.8*
+Pin-Priority: 1001


### PR DESCRIPTION
## What

Stopgap: pin `proxysql` to `3.0.8*` (Pin-Priority 1001) in the apt
preferences for the affected releases, so the kolla keepalived health
check keeps working and the internal API VIP stays up.

## Why

proxysql **3.0.9** ships the fix for [GHSA-58ww-865x-grpr](https://github.com/sysown/proxysql/security/advisories/GHSA-58ww-865x-grpr)
(a pre-auth heap overflow: an oversized first-packet length is passed to
`recv()` into a 32 KB buffer). The fix now **closes any connection whose
first packet exceeds that bound**.

kolla-ansible's keepalived `check_alive_proxysql.sh` probes liveness by
sending the raw string `show info` to the proxysql admin socket, which
speaks the MySQL wire protocol. proxysql reads the first bytes `"sho"` as
a packet length of 7,301,235 bytes, so 3.0.9 closes the connection and the
check fails. keepalived's `track_script` then goes to FAULT on every
control node at once → no node holds the `api-int` VIP → the loadbalancer
`Wait for ... to listen on VIP` handler times out (300s) → everything
hitting api-int fails with `No route to host` (Errno 113). proxysql 3.0.8
and earlier tolerated the malformed packet, so the check passed.

Reproduced deterministically in isolation (podman A/B): the exact check
never passes against the rolling `proxysql:2024.2` image (3.0.9) and passes
in ~1.2s against `release/proxysql:3.0.3`; the breaking commit
(`proxysql 1cb2ecc17`) is present in `v3.0.9` only. Onset matches — the
nightly testbed deploys started failing 2026-06-08, the first nightly to
pull proxysql 3.0.9 (released 2026-06-04).

## The real fix (upstream)

This pin is a **workaround**, not the fix — 3.0.8 itself carries
GHSA-58ww-865x-grpr. The proper fix is upstream and currently
**master-only**:

- **kolla-ansible [992020](https://review.opendev.org/c/openstack/kolla-ansible/+/992020)**
  — "proxysql: fix keepalived healthcheck to use MySQL protocol" (the real fix)
- depends on **kolla [992239](https://review.opendev.org/c/openstack/kolla/+/992239)**
  — "keepalived: Install mariadb client package"

**Drop this pin once both are backported to the releases we run.**

## Scope

Pinned in `templates/{2024.1,2024.2,2025.1,2025.2}/apt_preferences.ubuntu.j2`.
2024.2 / 2025.1 / 2025.2 are rebuilt nightly and currently exposed; 2024.1
is added defensively (its images are frozen on an older proxysql today, but
it is an upstream SLURP release and would break if respun).

## ⚠️ Before merge

Confirm `proxysql 3.0.8` is still available in the proxysql apt repo
(`proxysql-3.0.x` channel). The pin forces 3.0.8; if the repo only keeps the
newest, the image build would fail to resolve the package. Draft until that
is verified.
