### PR TITLE
check-and-repush: log discarded pull error

### DIFF
--- a/scripts/120-check-and-repush.sh
+++ b/scripts/120-check-and-repush.sh
@@ -174,9 +174,15 @@ compare_layer_digests() {
 
     log_verbose "Pulling remote image to temporary tag: $temp_remote_tag"
 
-    # Pull the remote image directly to temporary tag to avoid overwriting local
-    if ! docker pull "$image" >/dev/null 2>&1; then
-        log_verbose "Failed to pull remote image: $image"
+    # Pull the remote image directly to temporary tag to avoid overwriting local.
+    # This function is only reached after check_image_exists() succeeded, so a
+    # pull failure here is anomalous (the registry reports the image as present
+    # but it cannot be pulled). Capture and log the real docker error instead of
+    # discarding it, so the cause (auth, manifest mismatch, network) is visible
+    # in the build log rather than hidden behind a generic message.
+    local pull_error
+    if ! pull_error=$(docker pull "$image" 2>&1 >/dev/null); then
+        log_warning "Failed to pull remote image for digest check: $image: ${pull_error:-unknown error}"
         return 1
     fi
 


### PR DESCRIPTION
## What

In `scripts/120-check-and-repush.sh`, `compare_layer_digests()` pulls the
remote image to compare its ID against the freshly built one. The pull ran as:

```sh
docker pull "$image" >/dev/null 2>&1
```

so on failure the real docker error was discarded and only a generic
`Failed to pull remote image: <image>` was logged at **verbose** level. This
function is only reached after `check_image_exists()` has already confirmed the
image is present on the registry, so a pull failure here is **anomalous** (the
registry advertises the image but it cannot be pulled). The failure is then
treated as a digest mismatch and the image is re-pushed.

This change captures the docker stderr and logs it at **warning** level with
the image name and the actual error text, keeping the existing behaviour
(return non-zero so the image is re-pushed).

```diff
-    if ! docker pull "$image" >/dev/null 2>&1; then
-        log_verbose "Failed to pull remote image: $image"
+    local pull_error
+    if ! pull_error=$(docker pull "$image" 2>&1 >/dev/null); then
+        log_warning "Failed to pull remote image for digest check: $image: ${pull_error:-unknown error}"
         return 1
     fi
```

## Why

This was found while diagnosing intermittent
`unauthorized ... action: push` failures in the nightly push jobs. The build
logs showed only the generic `Failed to pull remote image` message, giving no
way to tell whether the underlying cause was authorization, a manifest
mismatch, or a transient network/registry problem — which made the failure
hard to triage. Logging the real error makes these diagnosable from the build
log alone.

## Logs where the error occurred

The discarded pull error precedes the visible push failure in these
`Run push script` tasks:

- `container-images-kolla-push-2025.1`, 2026-06-14 — build page
  <https://zuul.services.osism.tech/t/osism/build/9e664e64de064835a1d0550e1599b5b6>
  / job-output
  <https://logs.services.osism.tech/9e6/osism/9e664e64de064835a1d0550e1599b5b6/job-output.txt>
  (`aodh-evaluator`, `designate-producer`, `octavia-health-manager`)
- `container-images-kolla-push-2025.2`, 2026-06-14 — build page
  <https://zuul.services.osism.tech/t/osism/build/2bcedd6afb1345af9d89333d1ef3e74a>
  / job-output
  <https://logs.services.osism.tech/2bc/osism/2bcedd6afb1345af9d89333d1ef3e74a/job-output.txt>
  (`aodh-expirer`, `designate-backend-bind9`, `octavia-worker`)
- `container-images-kolla-push-2025.2`, 2026-05-31 — build page
  <https://zuul.services.osism.tech/t/osism/build/7a82c0076f774befa573d7652de842e9>
  / job-output
  <https://logs.services.osism.tech/7a8/osism/7a82c0076f774befa573d7652de842e9/job-output.txt>
  (transient: `ovn-northd` failed once, recovered on re-push, build SUCCESS)

In each, the log shows `Failed to pull remote image: …` with no underlying
cause; with this change it would also show the docker error (e.g. the
`unauthorized` / manifest / network detail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)