### PR TITLE
Pin valkey via SBOM_IMAGE_TO_VERSION

### DIFF
--- a/src/tag-images-with-the-version.py
+++ b/src/tag-images-with-the-version.py
@@ -337,6 +337,7 @@ SBOM_IMAGE_TO_VERSION = {
     "swift": "swift-object",
     "tgtd": "tgtd",
     "trove": "trove-api",
+    "valkey": "valkey-server",
     "watcher": "watcher-api",
 }
 


### PR DESCRIPTION
The kolla-ansible versions template reads `versions['valkey']` (rendered as `kolla_valkey_version`, defaulting to `openstack_version`), but `SBOM_IMAGE_TO_VERSION` never maps a valkey key, so the SBOM versions block omits it and the pin stays inert, silently falling back to `openstack_version`.

valkey is enabled in OSISM and buildable upstream (openstack/kolla `docker/valkey`), so the pin should resolve to a real built image rather than be removed. This maps `valkey` to the deployable server image `valkey-server` (the `valkey-base` layer is skipped, matching how `redis` maps to its server image).

This closes the **version-pin** half of the valkey chain flagged by the image-drift detector (`kolla_version_chain_inner`); the build set is added separately in osism/release:

- osism/release#2551