### PR TITLE
Build neutron images for 2024.1

### DIFF
--- a/defaults/2024.1.sh
+++ b/defaults/2024.1.sh
@@ -1,4 +1,4 @@
 export BUILD_ID=$(date +%Y%m%d)
-export KOLLA_IMAGES="^nova ^glance ^keystone"
+export KOLLA_IMAGES="^nova ^glance ^keystone ^neutron"
 export KOLLA_TYPE=
 export BASE_VERSION=22.04


### PR DESCRIPTION
These are needed once again after the recent CVE.